### PR TITLE
debuggerd: Disable scudo usage

### DIFF
--- a/debuggerd/Android.bp
+++ b/debuggerd/Android.bp
@@ -249,13 +249,6 @@ cc_library_static {
         debuggable: {
             cflags: ["-DROOT_POSSIBLE"],
         },
-
-        malloc_not_svelte: {
-            cflags: ["-DUSE_SCUDO"],
-            whole_static_libs: ["libscudo"],
-            srcs: ["libdebuggerd/scudo.cpp"],
-            header_libs: ["scudo_headers"],
-        },
     },
 }
 

--- a/fs_mgr/liblp/writer.cpp
+++ b/fs_mgr/liblp/writer.cpp
@@ -138,8 +138,8 @@ static bool ValidateAndSerializeMetadata([[maybe_unused]] const IPartitionOpener
             PERROR << partition_name << ": ioctl";
             return false;
         }
-        if (info.size != block_device.size) {
-            LERROR << "Block device " << partition_name << " size mismatch (expected"
+        if (info.size < block_device.size) {
+            LERROR << "Block device " << partition_name << " size is too small (expected"
                    << block_device.size << ", got " << info.size << ")";
             return false;
         }


### PR DESCRIPTION
Since we have switched to jemalloc (bionic).